### PR TITLE
Fix extension process IO

### DIFF
--- a/G-Earth/src/main/java/gearth/services/extension_handler/extensions/implementations/network/executer/NormalExtensionRunner.java
+++ b/G-Earth/src/main/java/gearth/services/extension_handler/extensions/implementations/network/executer/NormalExtensionRunner.java
@@ -1,6 +1,7 @@
 package gearth.services.extension_handler.extensions.implementations.network.executer;
 
 import gearth.GEarth;
+import gearth.misc.OSValidator;
 import gearth.services.extension_handler.extensions.implementations.network.NetworkExtensionAuthenticator;
 import gearth.services.internal_extensions.extensionstore.tools.StoreExtensionTools;
 import org.slf4j.Logger;
@@ -109,7 +110,7 @@ public final class NormalExtensionRunner implements ExtensionRunner {
             }
 
             final ProcessBuilder processBuilder = new ProcessBuilder(execCommand);
-            final Process process = processBuilder.start();
+            final Process process = startProcess(processBuilder);
 
             maybeLogExtension(path, process);
 
@@ -118,6 +119,15 @@ public final class NormalExtensionRunner implements ExtensionRunner {
         }
     }
 
+    public static Process startProcess(ProcessBuilder processBuilder) throws IOException {
+        // Redirect output streams if logging is not enabled to prevent lockup.
+        if (!GEarth.hasFlag(ExtensionRunner.SHOW_EXTENSIONS_LOG)) {
+            processBuilder.redirectErrorStream(true);
+            processBuilder.redirectOutput(new File(OSValidator.isWindows() ? "NUL" : "/dev/null"));
+        }
+
+        return processBuilder.start();
+    }
 
     public static void maybeLogExtension(String path, Process process) {
         if (GEarth.hasFlag(ExtensionRunner.SHOW_EXTENSIONS_LOG)) {

--- a/G-Earth/src/main/java/gearth/services/internal_extensions/extensionstore/tools/StoreExtensionTools.java
+++ b/G-Earth/src/main/java/gearth/services/internal_extensions/extensionstore/tools/StoreExtensionTools.java
@@ -52,7 +52,7 @@ public class StoreExtensionTools {
 
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(new File(Paths.get(extensionPath, "extension").toString()));
-            Process p = pb.start();
+            Process p = NormalExtensionRunner.startProcess(pb);
             NormalExtensionRunner.maybeLogExtension(extensionPath, p);
 
         } catch (IOException e) {


### PR DESCRIPTION
This PR fixes weird behaviour of extensions that output to the terminal. This is due to G-Earth not consuming output of the extension process, as documented on the [Process](https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/Process.html) page from Oracle's website:

> Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.

It adds the `NormalExtensionRunner.startProcess` method that simply redirects standard output and error to `NUL` on Windows and `/dev/null` on other systems before starting the process if logging is not enabled.

I wrote a small [extension](https://github.com/xabbo/g-terminal-test) to test and reproduce this behaviour which works by writing 1024 bytes to stdout every 100ms, then detecting and reporting write errors or lockups to G-Earth's extension console.

From my tests on Linux the extension consistently locks up after writing 65536 bytes when run as an installed extension. On Windows, sometimes the Write call returns an error but continues to write 0 bytes. Other times it locks up at 4096 bytes. This would explain some of the inconsistent behaviour I've seen some people report in the Discord server.

I have tested the fix on Linux and Windows and can confirm no lockups occur when writing to standard output as well as standard error, and that the `--log-extensions` flag still works as intended.