### PR TITLE
fix(packet-info): release semaphore on provider failure

### DIFF
--- a/G-Earth/src/main/java/gearth/app/services/packet_info/PacketInfoManagerRemote.java
+++ b/G-Earth/src/main/java/gearth/app/services/packet_info/PacketInfoManagerRemote.java
@@ -39,12 +39,18 @@ public class PacketInfoManagerRemote {
                 List<PacketInfo> synchronizedResult = Collections.synchronizedList(result);
                 for (RemotePacketInfoProvider provider : providers) {
                     new Thread(() -> {
-                        final List<PacketInfo> packets = provider.provide();
-                        if (!packets.isEmpty()) {
-                            synchronizedResult.addAll(packets);
-                            version.set(provider.getHotelVersion());
+                        try {
+                            final List<PacketInfo> packets = provider.provide();
+                            if (!packets.isEmpty()) {
+                                synchronizedResult.addAll(packets);
+                                version.set(provider.getHotelVersion());
+                            }
+                        } catch (Throwable t) {
+                            // Never let a provider crash deadlock the semaphore wait below.
+                            LOG.error("Packet info provider {} failed", provider.getClass().getSimpleName(), t);
+                        } finally {
+                            blockUntilComplete.release();
                         }
-                        blockUntilComplete.release();
                     }).start();
                 }
 


### PR DESCRIPTION
PacketInfoManagerRemote.fromHotelVersion spawns one thread per RemotePacketInfoProvider and blocks on a Semaphore until every thread calls release(). If any provider.provide() throws, the thread dies without releasing the semaphore and the caller blocks in blockUntilComplete.acquire() until something else interrupts it (e.g. the proxy connect attempt timing out ~12s later, surfacing as an InterruptedException in app.log).

Wrap each provider thread body in try/finally so blockUntilComplete.release() always runs, and log the throwable so the underlying provider failure is no longer silently swallowed by thread death.