### PR TITLE
Adjust gitignore files to consider subprojects as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,12 @@ bin/
 
 # vsCode
 Extensions/BlockReplacePackets/.classpath
-.project
-.settings/org.eclipse.m2e.core.prefs
 .vscode/launch.json
 
-*.classpath
-*.project
-*.settings/org.eclipse.jdt.apt.core.prefs
-*.settings/org.eclipse.jdt.core.prefs
-*.settings/org.eclipse.m2e.core.prefs
+# eclipse
+.classpath
+.project
+.settings/
 
 # Certificates
 *.p12


### PR DESCRIPTION
When building with eclipse, with current gitignore, we have the following untracked files showing up :
<img width="486" height="336" alt="image" src="https://github.com/user-attachments/assets/f4a7b362-97a4-4730-b392-f74432fb5e90" />

Changes on the gitignore is fixing that