### PR TITLE
Fix parsing HEntity

### DIFF
--- a/G-Earth-Api/src/main/java/gearth/extensions/parsers/HEntity.java
+++ b/G-Earth-Api/src/main/java/gearth/extensions/parsers/HEntity.java
@@ -35,7 +35,7 @@ public class HEntity {
 
         switch (entityTypeId) {
             case 1:
-                stuff = new Object[5];
+                stuff = new Object[6];
                 gender = HGender.fromString(packet.readString());
                 stuff[0] = packet.readInteger();
                 stuff[1] = packet.readInteger();
@@ -43,6 +43,7 @@ public class HEntity {
                 stuff[2] = packet.readString();
                 stuff[3] = packet.readInteger();
                 stuff[4] = packet.readBoolean();
+                stuff[5] = packet.readInteger();
                 break;
             case 2:
                 stuff = new Object[12];


### PR DESCRIPTION
Following the discussion on [discord](https://discord.com/channels/744927320871010404/744930901204402339/1507876622588706928), it seems more like a Badge Rank has been added to the user entity.

Since user entity type == 1 is the user, simple fix seem to add the additional read integer.

Without such fix, `HEntity.parse` fail in rooms with more than one user. It is caused by that additional integer that overlaps over the next entity that will be parsed.