### PR TITLE
Feature : Dispatch language change over extensions

### DIFF
--- a/G-Earth-Api/src/main/java/gearth/extensions/ExtensionBase.java
+++ b/G-Earth-Api/src/main/java/gearth/extensions/ExtensionBase.java
@@ -30,7 +30,16 @@ public abstract class ExtensionBase extends IExtension {
     ObservableObject<HostInfo> observableHostInfo = new ObservableObject<>(null);
 
     public void updateHostInfo(HostInfo hostInfo) {
+        String oldLanguage = getLanguage(observableHostInfo.getObject());
         observableHostInfo.setObject(hostInfo);
+        String newLanguage = getLanguage(hostInfo);
+        if (newLanguage != null && !newLanguage.equals(oldLanguage)) {
+            handleLanguageChange(newLanguage);
+        }
+    }
+
+    private static String getLanguage(HostInfo info) {
+        return info != null && info.getAttributes() != null ? info.getAttributes().get("language") : null;
     }
 
     /**
@@ -191,4 +200,11 @@ public abstract class ExtensionBase extends IExtension {
     public HostInfo getHostInfo() {
         return observableHostInfo.getObject();
     }
+
+    /**
+     * Called when the G-Earth language changes.
+     * Override this method to react to language changes.
+     * @param locale the new language locale code (e.g. "en", "fr", "de")
+     */
+    public void handleLanguageChange(String locale) {}
 }

--- a/G-Earth-Api/src/main/java/gearth/extensions/ExtensionFormLauncher.java
+++ b/G-Earth-Api/src/main/java/gearth/extensions/ExtensionFormLauncher.java
@@ -55,6 +55,11 @@ public class ExtensionFormLauncher extends Application {
             public boolean canDelete() {
                 return extensionForm.canDelete();
             }
+
+            @Override
+            public void handleLanguageChange(String locale) {
+                extensionForm.handleLanguageChange(locale);
+            }
         };
         extensionForm.hostServices = getHostServices();
         extensionForm.extension = extension;

--- a/G-Earth/src/main/java/gearth/app/GEarth.java
+++ b/G-Earth/src/main/java/gearth/app/GEarth.java
@@ -36,6 +36,7 @@ public class GEarth extends Application {
     public static String storeVersion;
     public static String repository;
     public static ObservableObject<Theme> observableTheme;
+    public static ObservableObject<Language> observableLanguage;
 
     private Stage stage;
     private GEarthController controller;
@@ -47,6 +48,7 @@ public class GEarth extends Application {
                         ThemeFactory.getDefaultTheme()
         );
 
+        observableLanguage = new ObservableObject<>(LanguageBundle.getLanguage());
 
         // Load build.properties
         try {
@@ -190,6 +192,10 @@ public class GEarth extends Application {
 
     public static ObservableObject<Theme> getThemeObservable() {
         return observableTheme;
+    }
+
+    public static ObservableObject<Language> getLanguageObservable() {
+        return observableLanguage;
     }
 
     public static Theme getTheme() {

--- a/G-Earth/src/main/java/gearth/app/services/extension_handler/ExtensionHandler.java
+++ b/G-Earth/src/main/java/gearth/app/services/extension_handler/ExtensionHandler.java
@@ -54,6 +54,14 @@ public class ExtensionHandler {
             }
         });
 
+        GEarth.getLanguageObservable().addListener(language -> {
+            synchronized (gEarthExtensions) {
+                for (GEarthExtension extension : gEarthExtensions) {
+                    extension.updateHostInfo(getHostInfo());
+                }
+            }
+        });
+
         hConnection.getStateObservable().addListener((oldState, newState) -> {
             if (newState == HState.CONNECTED) {
                 synchronized (gEarthExtensions) {
@@ -274,6 +282,7 @@ public class ExtensionHandler {
     private HostInfo getHostInfo() {
         HashMap<String, String> attributes = new HashMap<>();
         attributes.put("theme", GEarth.getTheme().title());
+        attributes.put("language", GEarth.getLanguageObservable().getObject().getLocale());
         return new HostInfo(
                 "G-Earth",
                 GEarth.version,

--- a/G-Earth/src/main/java/gearth/app/ui/translations/Language.java
+++ b/G-Earth/src/main/java/gearth/app/ui/translations/Language.java
@@ -64,6 +64,10 @@ public enum Language {
         return icon;
     }
 
+    public String getLocale() {
+        return locale;
+    }
+
     public static MenuItem[] getMenuItems() {
         return Arrays.stream(values())
                 .map(Language::asMenuItem)

--- a/G-Earth/src/main/java/gearth/app/ui/translations/LanguageBundle.java
+++ b/G-Earth/src/main/java/gearth/app/ui/translations/LanguageBundle.java
@@ -1,5 +1,6 @@
 package gearth.app.ui.translations;
 
+import gearth.app.GEarth;
 import gearth.app.misc.Cacher;
 
 import java.util.Enumeration;
@@ -40,6 +41,9 @@ public class LanguageBundle extends ResourceBundle {
         current = lang;
         requireUpdate.forEach(TranslatableString::trigger);
         Cacher.put(LANGUAGE_CACHE_KEY, current.toString());
+        if (GEarth.observableLanguage != null) {
+            GEarth.observableLanguage.setObject(lang);
+        }
     }
 
     public static Language getLanguage() {


### PR DESCRIPTION
Currently, extensions does not have any way to know the G-Earth language except doing a trick :
1. Get G-Earth folder
2. Listen on its cache file to check on language keyword
3. When language changes (e.g. FRENCH becomes ENGLISH), the extension would handle that change

Because the languages are not stored in their iso format (ISO 639-1), and this is not at all a clean way to do it, the approach is about dispatching the language change everytime the user changes it; just like we do for the theme.

The good thing, is that we already have the map for the theme, therefore I chose to send additional attribute on that map.

Here is a quick example once I overrode that on my plugin (of course this is a quick simple example I did)
<img width="800" height="453" alt="plants_language_change" src="https://github.com/user-attachments/assets/61420667-1da0-4fe2-b33f-fd770fdeac9d" />
