### PR TITLE
Bugfix : Fix memory leak when cleaning Packet Logger history

### DIFF
--- a/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
@@ -390,6 +390,7 @@ public class UiLoggerController implements Initializable {
 
     public void clearText(ActionEvent actionEvent) {
         area.clear();
+        System.gc();
     }
 
     public void onDisconnect() {

--- a/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
@@ -161,6 +161,8 @@ public class UiLoggerController implements Initializable {
         area = new StyleClassedTextArea();
         area.getStyleClass().add("dark");
         area.setWrapText(true);
+        // RichTextFX keeps unlimited rich-text undo history by default, which retains cleared packet logs.
+        area.setUndoManager(null);
 
         VirtualizedScrollPane<StyleClassedTextArea> vsPane = new VirtualizedScrollPane<>(area);
         borderPane.setCenter(vsPane);
@@ -389,6 +391,8 @@ public class UiLoggerController implements Initializable {
 
     public void clearText(ActionEvent actionEvent) {
         area.clear();
+        area.getUndoManager().forgetHistory();
+        System.gc();
     }
 
     public void onDisconnect() {

--- a/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
@@ -161,7 +161,6 @@ public class UiLoggerController implements Initializable {
         area = new StyleClassedTextArea();
         area.getStyleClass().add("dark");
         area.setWrapText(true);
-        // RichTextFX keeps unlimited rich-text undo history by default, which retains cleared packet logs.
         area.setUndoManager(null);
 
         VirtualizedScrollPane<StyleClassedTextArea> vsPane = new VirtualizedScrollPane<>(area);
@@ -391,8 +390,6 @@ public class UiLoggerController implements Initializable {
 
     public void clearText(ActionEvent actionEvent) {
         area.clear();
-        area.getUndoManager().forgetHistory();
-        System.gc();
     }
 
     public void onDisconnect() {

--- a/G-Earth/src/main/java/gearth/app/ui/subforms/extensions/logger/ExtensionLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/ui/subforms/extensions/logger/ExtensionLoggerController.java
@@ -27,6 +27,8 @@ public class ExtensionLoggerController implements Initializable {
         area.getStyleClass().add("themed-background");
         area.setWrapText(true);
         area.setEditable(false);
+        // RichTextFX keeps unlimited rich-text undo history by default; logs do not need it.
+        area.setUndoManager(null);
 
         VirtualizedScrollPane<StyleClassedTextArea> vsPane = new VirtualizedScrollPane<>(area);
         borderPane.setCenter(vsPane);

--- a/G-Earth/src/main/java/gearth/app/ui/subforms/extensions/logger/ExtensionLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/ui/subforms/extensions/logger/ExtensionLoggerController.java
@@ -27,7 +27,6 @@ public class ExtensionLoggerController implements Initializable {
         area.getStyleClass().add("themed-background");
         area.setWrapText(true);
         area.setEditable(false);
-        // RichTextFX keeps unlimited rich-text undo history by default; logs do not need it.
         area.setUndoManager(null);
 
         VirtualizedScrollPane<StyleClassedTextArea> vsPane = new VirtualizedScrollPane<>(area);


### PR DESCRIPTION
After analyzing why G-Earth's memory is keeping increasing indefinitely without any possibility to reduce that, I noticed that many retained object instances were openjfx elements : to be more precise Packet Logger Spans that we keep so the user can track the packets.

However, even by cleaning those packets, memory held by G-Earth was still the same and does not deflate (even by calling `System.gc()` ).
This is because of the default `UndoManager` of `StyleClassedTextArea` that would is holding the instances of every element, for any potential undo operation.

Note that I am working on another PR which is about time-based log retention : it would mitigate the daily usage for user (no need of Memory retention) and Extension Developer usage that would need the Packet Logger completely or partially (consume more memory over time) :  This will come as functionality on a separate PR and fix the memory issue by design with its default behavior.