### PR TITLE
Fix selection when user selected (and while selecting) then receiving packets

### DIFF
--- a/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
@@ -365,7 +365,7 @@ public class UiLoggerController implements Initializable {
             int caret = area.getCaretPosition();
             boolean hasSelection = anchor != caret;
 
-            area.replaceText(oldLen, oldLen, sb.toString());
+            area.appendText(sb.toString());
             area.setStyleSpans(oldLen, styleSpansBuilder.create());
 
             if (hasSelection) {

--- a/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
+++ b/G-Earth/src/main/java/gearth/app/services/internal_extensions/uilogger/UiLoggerController.java
@@ -82,6 +82,7 @@ public class UiLoggerController implements Initializable {
 
     private int filteredAmount = 0;
 
+    private long lastMouseReleaseTime = 0;
     private volatile boolean initialized = false;
     private final List<Element> appendLater = new ArrayList<>();
 
@@ -162,6 +163,7 @@ public class UiLoggerController implements Initializable {
         area.getStyleClass().add("dark");
         area.setWrapText(true);
         area.setUndoManager(null);
+        area.setOnMouseReleased(e -> lastMouseReleaseTime = System.currentTimeMillis());
 
         VirtualizedScrollPane<StyleClassedTextArea> vsPane = new VirtualizedScrollPane<>(area);
         borderPane.setCenter(vsPane);
@@ -358,11 +360,35 @@ public class UiLoggerController implements Initializable {
             }
 
             int oldLen = area.getLength();
+            
+            int anchor = area.getAnchor();
+            int caret = area.getCaretPosition();
+            boolean hasSelection = anchor != caret;
 
-            area.appendText(sb.toString());
+            area.replaceText(oldLen, oldLen, sb.toString());
             area.setStyleSpans(oldLen, styleSpansBuilder.create());
 
-            if (chkAutoscroll.isSelected()) {
+            if (hasSelection) {
+                area.selectRange(anchor, caret);
+                
+                final int savedAnchor = anchor;
+                Platform.runLater(() -> {
+                    if (area.getAnchor() == savedAnchor) {
+                        int currentCaret = area.getCaretPosition();
+                        area.deselect();
+                        area.selectRange(savedAnchor, currentCaret);
+                    }
+                });
+            } else {
+                area.moveTo(caret);
+            }
+
+            boolean isMouseHeld = area.isPressed();
+            boolean isGracePeriod = System.currentTimeMillis() - lastMouseReleaseTime < 500;
+            boolean isUserSelecting = hasSelection || isMouseHeld || isGracePeriod;
+
+            if (chkAutoscroll.isSelected() && !isUserSelecting) {
+                area.moveTo(area.getLength());
                 area.requestFollowCaret();
             }
         });


### PR DESCRIPTION
I noticed a huge issue about selecting while there is a lot texts going on : It removes the current selection.
Therefore, this ticket is about :
* Fixing the issue : force keeping user selection when packet is added to logger area.
* Disable Auto-scrolling when user is selecting, because keeping it enable for this case doesn't really make sense
* Keeping Autoscroll disabled for 0.5s after user removes selection : If the user tries to adjust the select, to not go directly autoscroll, autoscroll directly would just not be user-friendly