### PR TITLE
Fix cropped tray icon

### DIFF
--- a/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
+++ b/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
@@ -48,7 +48,9 @@ public final class GEarthTrayIcon {
             menu.addSeparator();
             menu.add(createInstallMenuItem());
             try {
-                SystemTray.getSystemTray().add(new TrayIcon(awtImage, appTitle, menu));
+                TrayIcon defaultTrayIcon = new TrayIcon(awtImage, appTitle, menu);
+                defaultTrayIcon.setImageAutoSize(true);
+                SystemTray.getSystemTray().add(defaultTrayIcon);
             } catch (AWTException e) {
                 e.printStackTrace();
                 menu = null;


### PR DESCRIPTION
You can see below before (on the left) vs after (on the right):
<img width="250" height="103" alt="image" src="https://github.com/user-attachments/assets/0605f53c-4dbd-4471-8066-c402d482fb8e" />