### PR TITLE
Feature : Add connection status indicator to system tray icon

### DIFF
--- a/G-Earth/src/main/java/gearth/app/ui/GEarthController.java
+++ b/G-Earth/src/main/java/gearth/app/ui/GEarthController.java
@@ -52,6 +52,8 @@ public class GEarthController {
     }
 
     public void initialize() {
+        GEarthTrayIcon.setHConnection(hConnection);
+
         tabs = new ArrayList<>();
         // must be ordered correctly
         tabs.add(connectionController);

--- a/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
+++ b/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
@@ -1,6 +1,8 @@
 package gearth.app.ui;
 
 import gearth.app.GEarth;
+import gearth.app.protocol.HConnection;
+import gearth.app.protocol.connection.HState;
 import gearth.services.extension_handler.extensions.GEarthExtension;
 import gearth.app.services.extension_handler.extensions.extensionproducers.ExtensionProducerFactory;
 import gearth.app.services.extension_handler.extensions.implementations.network.NetworkExtensionServer;
@@ -10,6 +12,7 @@ import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 import java.awt.*;
+import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,22 +28,35 @@ public final class GEarthTrayIcon {
     private static final String TO_FRONT_LABEL = "To front";
     private static final String TO_BACK_LABEL = "To back";
 
+    private static final int DOT_DIAMETER = 15;
+    private static final int DOT_MARGIN = 1;
+
     private static PopupMenu menu;
+    private static Image baseImage;
+    private static TrayIcon currentTrayIcon;
+    private static HState currentState = HState.NOT_CONNECTED;
+
+    public static void setHConnection(HConnection hConnection) {
+        hConnection.getStateObservable().addListener((oldState, newState) ->
+                Platform.runLater(() -> onStateChanged(newState)));
+    }
 
     public static void updateOrCreate(Image image) {
 
         if (!SystemTray.isSupported())
             return;
 
+        baseImage = image;
+
         final NetworkExtensionServer server = ExtensionProducerFactory.getExtensionServer();
-        final BufferedImage awtImage = SwingFXUtils.fromFXImage(image, null);
         final String appTitle = "G-Earth " + GEarth.version + " (" + server.getPort() + ")";
 
         final Optional<TrayIcon> trayIcon = Stream.of(SystemTray.getSystemTray().getTrayIcons())
                 .filter(other -> Objects.equals(other.getToolTip(), appTitle))
                 .findFirst();
         if (trayIcon.isPresent()) {
-            EventQueue.invokeLater(() -> trayIcon.get().setImage(awtImage));
+            currentTrayIcon = trayIcon.get();
+            EventQueue.invokeLater(() -> currentTrayIcon.setImage(composeIconWithDot(baseImage, currentState)));
         } else {
             menu = new PopupMenu();
             menu.add(createToFrontOrBackMenuItem());
@@ -48,14 +64,48 @@ public final class GEarthTrayIcon {
             menu.addSeparator();
             menu.add(createInstallMenuItem());
             try {
-                TrayIcon defaultTrayIcon = new TrayIcon(awtImage, appTitle, menu);
-                defaultTrayIcon.setImageAutoSize(true);
-                SystemTray.getSystemTray().add(defaultTrayIcon);
+                currentTrayIcon = new TrayIcon(composeIconWithDot(baseImage, currentState), appTitle, menu);
+                currentTrayIcon.setImageAutoSize(true);
+                SystemTray.getSystemTray().add(currentTrayIcon);
             } catch (AWTException e) {
                 e.printStackTrace();
                 menu = null;
+                currentTrayIcon = null;
             }
         }
+    }
+
+    private static void onStateChanged(HState newState) {
+        currentState = newState;
+        if (currentTrayIcon != null && baseImage != null) {
+            final BufferedImage composed = composeIconWithDot(baseImage, newState);
+            EventQueue.invokeLater(() -> currentTrayIcon.setImage(composed));
+        }
+    }
+
+    private static BufferedImage composeIconWithDot(Image fxImage, HState state) {
+        final BufferedImage awtImage = SwingFXUtils.fromFXImage(fxImage, null);
+        if (awtImage == null) return null;
+
+        final Color dotColor;
+        switch (state) {
+            case CONNECTED:     dotColor = Color.GREEN;  break;
+            case NOT_CONNECTED: dotColor = Color.RED;    break;
+            default:            dotColor = Color.ORANGE;  break;
+        }
+
+        drawStatusDot(awtImage, dotColor);
+        return awtImage;
+    }
+
+    private static void drawStatusDot(BufferedImage image, Color color) {
+        final Graphics2D g2 = image.createGraphics();
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setColor(color);
+        double x = image.getWidth() - DOT_DIAMETER - DOT_MARGIN;
+        double y = image.getHeight() - DOT_DIAMETER - DOT_MARGIN;
+        g2.fill(new Ellipse2D.Double(x, y, DOT_DIAMETER, DOT_DIAMETER));
+        g2.dispose();
     }
 
     private static MenuItem createToFrontOrBackMenuItem() {


### PR DESCRIPTION
Add a small "dot" icon next to the system tray icon to show connection status with habbo :
* Green : connected
* Orange : any intermediate state
* Red : disconnected

Example :
<img width="251" height="95" alt="image" src="https://github.com/user-attachments/assets/d5af25bf-4c95-492a-8df7-8ace60b35232" />

Happened to me a lot where I thought I was connected with G-Earth but actually was not.
This could really help to identify such thing easily.