### PR TITLE
Bugfix : Bring G-Earth to front when clicking on its System Tray icon

### DIFF
--- a/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
+++ b/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
@@ -10,6 +10,8 @@ import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,6 +52,20 @@ public final class GEarthTrayIcon {
             try {
                 TrayIcon defaultTrayIcon = new TrayIcon(awtImage, appTitle, menu);
                 defaultTrayIcon.setImageAutoSize(true);
+                defaultTrayIcon.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        if (e.getButton() == MouseEvent.BUTTON1) {
+                            Platform.runLater(() -> {
+                                final Stage stage = GEarth.main.getController().getStage();
+                                if (stage.isIconified()) {
+                                    stage.setIconified(false);
+                                }
+                                stage.toFront();
+                            });
+                        }
+                    }
+                });
                 SystemTray.getSystemTray().add(defaultTrayIcon);
             } catch (AWTException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Currently, nothing happens when clicking on the System Tray icon.
The following change make it to "remove it being minimized" + bring it to front.
Which make it easier to open whatever G-Earth you want to open just by clicking to its related System Tray Icon

Need to be careful, this PR is in conflict with this PR : https://github.com/G-Realm/G-Earth/pull/33
Variable name need to be renamed accordingly