### PR TITLE
Feature : Add option keep running in background

### DIFF
--- a/G-Earth/src/main/java/gearth/app/GEarth.java
+++ b/G-Earth/src/main/java/gearth/app/GEarth.java
@@ -133,6 +133,10 @@ public class GEarth extends Application {
     }
 
     private void closeGEarth() {
+        if (controller.connectionController.isKeepRunningInBackground()) {
+            stage.hide();
+            return;
+        }
         controller.exit();
         Platform.exit();
         System.exit(0);

--- a/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
+++ b/G-Earth/src/main/java/gearth/app/ui/GEarthTrayIcon.java
@@ -10,6 +10,8 @@ import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,9 +49,26 @@ public final class GEarthTrayIcon {
             menu.addSeparator();
             menu.addSeparator();
             menu.add(createInstallMenuItem());
+            menu.addSeparator();
+            menu.add(createQuitMenuItem());
             try {
                 TrayIcon defaultTrayIcon = new TrayIcon(awtImage, appTitle, menu);
                 defaultTrayIcon.setImageAutoSize(true);
+                defaultTrayIcon.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        if (e.getButton() == MouseEvent.BUTTON1) {
+                            Platform.runLater(() -> {
+                                final Stage stage = GEarth.main.getController().getStage();
+                                if (stage.isIconified()) {
+                                    stage.setIconified(false);
+                                }
+                                stage.show();
+                                stage.toFront();
+                            });
+                        }
+                    }
+                });
                 SystemTray.getSystemTray().add(defaultTrayIcon);
             } catch (AWTException e) {
                 e.printStackTrace();
@@ -85,6 +104,16 @@ public final class GEarthTrayIcon {
                             stage.setAlwaysOnTop(isOnTop);
                         })));
         return showMenuItem;
+    }
+
+    private static MenuItem createQuitMenuItem() {
+        final MenuItem quitMenuItem = new MenuItem("Quit");
+        quitMenuItem.addActionListener(e -> Platform.runLater(() -> {
+            GEarth.main.getController().exit();
+            Platform.exit();
+            System.exit(0);
+        }));
+        return quitMenuItem;
     }
 
     /**

--- a/G-Earth/src/main/java/gearth/app/ui/subforms/connection/ConnectionController.java
+++ b/G-Earth/src/main/java/gearth/app/ui/subforms/connection/ConnectionController.java
@@ -26,6 +26,7 @@ public class ConnectionController extends SubForm {
     private final String AUTODETECT_CACHE = "auto_detect";
     private final String HOST_CACHE = "host";
     private final String PORT_CACHE = "port";
+    private static final String KEEP_RUNNING_IN_BACKGROUND_CACHE_KEY = "keep_running_in_background";
 
     public ComboBox<String> inpPort;
     public ComboBox<String> inpHost;
@@ -34,6 +35,7 @@ public class ConnectionController extends SubForm {
     public TextField outHost;
     public TextField outPort;
     public CheckBox cbx_autodetect;
+    public CheckBox cbx_keepRunningInBackground;
     public TextField txtfield_hotelversion;
 
     private final Object lock = new Object();
@@ -75,6 +77,10 @@ public class ConnectionController extends SubForm {
                     rd_nitro.setSelected(true);
                     break;
             }
+        }
+
+        if (Cacher.getCacheContents().has(KEEP_RUNNING_IN_BACKGROUND_CACHE_KEY)) {
+            cbx_keepRunningInBackground.setSelected(Cacher.getCacheContents().getBoolean(KEEP_RUNNING_IN_BACKGROUND_CACHE_KEY));
         }
 
 
@@ -308,6 +314,7 @@ public class ConnectionController extends SubForm {
         } else if (rd_nitro.isSelected()) {
             Cacher.put(CLIENT_CACHE_KEY, HClient.NITRO);
         }
+        Cacher.put(KEEP_RUNNING_IN_BACKGROUND_CACHE_KEY, cbx_keepRunningInBackground.isSelected());
         getHConnection().abort();
     }
 
@@ -334,6 +341,10 @@ public class ConnectionController extends SubForm {
         return false;
     }
 
+    public boolean isKeepRunningInBackground() {
+        return cbx_keepRunningInBackground.isSelected();
+    }
+
     private void initLanguageBinding() {
         TranslatableString port = new TranslatableString("%s", "tab.connection.port");
         TranslatableString host = new TranslatableString("%s", "tab.connection.host");
@@ -353,5 +364,6 @@ public class ConnectionController extends SubForm {
         lblStateHead.textProperty().bind(new TranslatableString("%s", "tab.connection.state"));
         state = new TranslatableString("%s", "tab.connection.state.notconnected");
         lblState.textProperty().bind(state);
+        cbx_keepRunningInBackground.textProperty().bind(new TranslatableString("%s", "tab.connection.options.keeprunninginbackground"));
     }
 }

--- a/G-Earth/src/main/resources/gearth/ui/subforms/connection/Connection.fxml
+++ b/G-Earth/src/main/resources/gearth/ui/subforms/connection/Connection.fxml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.text.Font?>
 
-<GridPane alignment="CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="258.0" prefWidth="650.0" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gearth.app.ui.subforms.connection.ConnectionController">
+<GridPane alignment="CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="258.0" prefWidth="650.0" xmlns="http://javafx.com/javafx/26" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gearth.app.ui.subforms.connection.ConnectionController">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
     </columnConstraints>
@@ -179,7 +187,7 @@
          </padding>
         </GridPane>
     </GridPane>
-    <GridPane alignment="CENTER" GridPane.rowIndex="1">
+    <GridPane alignment="TOP_LEFT" GridPane.rowIndex="1">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="340.0" minWidth="10.0" prefWidth="208.0" />
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="380.0" minWidth="10.0" prefWidth="357.0" />
@@ -190,20 +198,21 @@
         <GridPane.margin>
             <Insets />
         </GridPane.margin>
-        <GridPane>
+        <GridPane alignment="TOP_LEFT">
             <columnConstraints>
                 <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
             </columnConstraints>
             <rowConstraints>
-                <RowConstraints maxHeight="62.0" minHeight="10.0" prefHeight="53.0" vgrow="SOMETIMES" />
-                <RowConstraints maxHeight="107.0" minHeight="10.0" prefHeight="85.0" vgrow="SOMETIMES" />
+                <RowConstraints maxHeight="25.0" minHeight="10.0" prefHeight="20.0" vgrow="NEVER" />
+                <RowConstraints maxHeight="40.0" minHeight="10.0" prefHeight="40.0" vgrow="SOMETIMES" />
+                <RowConstraints maxHeight="32.0" minHeight="10.0" prefHeight="32.0" vgrow="SOMETIMES" />
             </rowConstraints>
             <GridPane.margin>
-                <Insets bottom="14.0" left="20.0" right="20.0" />
+                <Insets left="20.0" right="20.0" top="12.0" />
             </GridPane.margin>
-            <Label fx:id="lblStateHead" text="Connection state:" textFill="#000000ba" GridPane.valignment="BOTTOM">
+            <Label fx:id="lblStateHead" text="Connection state:" textFill="#000000ba" GridPane.valignment="TOP">
                 <GridPane.margin>
-                    <Insets bottom="5.0" left="2.0" />
+                    <Insets left="2.0" />
                 </GridPane.margin>
                 <font>
                     <Font size="12.0" />
@@ -214,6 +223,11 @@
                     <Insets />
                 </GridPane.margin>
             </Label>
+            <CheckBox fx:id="cbx_keepRunningInBackground" mnemonicParsing="false" text="Keep running in background" textFill="#000000a9" GridPane.rowIndex="2" GridPane.valignment="BOTTOM">
+                <GridPane.margin>
+                    <Insets left="2.0" top="4.0" />
+                </GridPane.margin>
+            </CheckBox>
         </GridPane>
         <GridPane style="-fx-border-color: #888888; -fx-border-radius: 5px; " GridPane.columnIndex="1">
             <columnConstraints>

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_de.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_de.properties
@@ -117,6 +117,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python Installation
 tab.extra.options.pythonscripting.alert.content=Bevor du G-Python verwendest, installiere die richtigen Pakete mit "pip"!
 tab.extra.options.pythonscripting.alert.moreinformation=Weitere Informationen hier:
 tab.extra.options.advanced=Erweitert
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=SOCKS Proxy benutzen
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy Port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_en.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_en.properties
@@ -112,6 +112,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python installation
 tab.extra.options.pythonscripting.alert.content=Before using G-Python, install the right packages using pip!
 tab.extra.options.pythonscripting.alert.moreinformation=More information here:
 tab.extra.options.advanced=Advanced
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Use SOCKS proxy
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_es.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_es.properties
@@ -115,6 +115,7 @@ tab.extra.options.pythonscripting.alert.title=Instalación de G-Python
 tab.extra.options.pythonscripting.alert.content=Antes de instalar G-Python, instala los paquetes con pip!
 tab.extra.options.pythonscripting.alert.moreinformation=Mas información aqui:
 tab.extra.options.advanced=Avanzado
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Usar proxy SOCKS
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_fi.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_fi.properties
@@ -114,6 +114,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python -asennus
 tab.extra.options.pythonscripting.alert.content=Ennen kuin käytät G-Pythonia, asenna oikeat paketit pip:llä!
 tab.extra.options.pythonscripting.alert.moreinformation=Lisätietoja täältä:
 tab.extra.options.advanced=Lisäasetukset
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Käytä SOCKS-proxya
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy-portti

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_fr.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_fr.properties
@@ -117,6 +117,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python installation
 tab.extra.options.pythonscripting.alert.content=Avant d'utiliser G-Python, installer les packages avec pip!
 tab.extra.options.pythonscripting.alert.moreinformation=Plus d'informations ici:
 tab.extra.options.advanced=Avancer
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Utiliser SOCKS proxy
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_it.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_it.properties
@@ -113,6 +113,7 @@ tab.extra.options.pythonscripting.alert.title=Installazione di G-Python
 tab.extra.options.pythonscripting.alert.content=Prima di usare G-Python, installare i pacchetti giusti usando pip!
 tab.extra.options.pythonscripting.alert.moreinformation=Maggiori informazion qui:
 tab.extra.options.advanced=Avanzato
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Usa Proxy SOCKS
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_nl.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_nl.properties
@@ -113,6 +113,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python installatie
 tab.extra.options.pythonscripting.alert.content=Voordat je G-Python kan gebruiken moet je de juiste packages installeren!
 tab.extra.options.pythonscripting.alert.moreinformation=Meer informatie hier:
 tab.extra.options.advanced=Geavanceerd
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Gebruik SOCKS proxy
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_pt.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_pt.properties
@@ -113,6 +113,7 @@ tab.extra.options.pythonscripting.alert.title=Instalação do G-Python
 tab.extra.options.pythonscripting.alert.content=Antes de usar G-Python, instale os pacotes corretos usando pip!
 tab.extra.options.pythonscripting.alert.moreinformation=Mais informações aqui:
 tab.extra.options.advanced=Avançado
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks=Usar proxy SOCKS
 tab.extra.options.advanced.proxy.ip=IP do proxy
 tab.extra.options.advanced.proxy.port=Porta do proxy

--- a/G-Earth/src/main/resources/gearth/ui/translations/messages_tr.properties
+++ b/G-Earth/src/main/resources/gearth/ui/translations/messages_tr.properties
@@ -115,6 +115,7 @@ tab.extra.options.pythonscripting.alert.title=G-Python Kurulum
 tab.extra.options.pythonscripting.alert.content=G-Python'u kullanmadan önce pip kullanarak doğru paketleri kurun!
 tab.extra.options.pythonscripting.alert.moreinformation =Daha fazla bilgi için:
 tab.extra.options.advanced =İleri
+tab.connection.options.keeprunninginbackground=Keep G-Earth running in background
 tab.extra.options.advanced.socks =SOCKS proxy kullanın
 tab.extra.options.advanced.proxy.ip=Proxy IP
 tab.extra.options.advanced.proxy.port=Proxy port


### PR DESCRIPTION
This is really useful for users that doesn't really need UI of G-Earth or its extension.
For example, extensions that provide commands (like G-Presets), there is very little benefit (or even none) to keep it on the App Bar when trying to close UI.

This is how it will look like :
<img width="649" height="321" alt="image" src="https://github.com/user-attachments/assets/c69b0b8d-4a21-4f27-8e8a-f7f31f0bc592" />

Plus, adding System Tray option "Quit" to close directly G-Earth from System Tray icons (useful when reduced there - stage hidden)
<img width="223" height="91" alt="image" src="https://github.com/user-attachments/assets/7007ed44-82eb-4423-8026-8a1ba44b0fca" />